### PR TITLE
fix(Docs: Architecture): Typographical changes and improved Readability

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,23 +8,23 @@ Please make sure you read the [glossary](/glossary.md) to have a better understa
 
 ## Scenario
 
-This scenario describes the steps of the above schema. Please note that most interactions are done through WebSockets.
+This scenario describes the steps of the above displayed schema. Please note that most interactions are done through the help of [WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API).
 
-1. Client (web app, etc.) makes an HTTP request to GET some information about Leon.
-2. [HTTP API](/glossary.md#api) responds information to client.
-3. User talks with their microphone.
+1. The Client (web app, etc.) makes an HTTP request to GET some information from Leon.
+2. The [HTTP API](/glossary.md#api) responds with information to client.
+3. The user talks using their microphone.
 4. <i style="opacity: 0;">.</i>
-	- a. If [hotword](/offline.md#hotword) server is launched, Leon listens (offline) if user is calling him by saying `Leon`.
-	- b. If Leon understands user is calling him, Leon emits a message to the main server via a WebSocket. Now Leon is listening (offline) to user.
-	- c. User said `Hello!` to Leon, client transforms the audio input to an audio blob.
+	- a. If [hotword](/offline.md#hotword) server is launched, Leon listens (offline) if the user is calling him by saying `Leon`.
+	- b. If Leon understands that the user is calling him, Leon emits a message to the main server via a WebSocket. Now Leon is listening (offline) to user.
+	- c. The User says `Hello!` to Leon, client transforms the audio input to an audio blob.
 5. [ASR](/glossary.md#asr) transforms audio blob to a wave file.
 6. [STT](/glossary.md#stt) parser transforms wave file to string (`Hello`).
 7. <i style="opacity: 0;">.</i>
-	- a. User receives string and string is forwarded to [NLU](/glossary.md#nlu).
-	- b. Or user type `Hello!` with their keyboard (and ignores steps 1. to 7.a.). `Hello!` string is forwarded to NLU.
-8. NLU classifies string and pick up classification.
+	- a. The user receives the string and string is forwarded to [NLU](/glossary.md#nlu).
+	- b. Or the user types `Hello!` with their keyboard (and ignores steps 1. to 7.a.). The `Hello!` string is forwarded to the NLU.
+8. The NLU classifies string and pick up the classification.
 9. If [collaborative logger](/collaborative-logger.md) is enabled, classification is sent to collaborative logger.
-10. [Brain](/glossary.md#brain) creates a child process and executes the chosen [module](/glossary.md#modules).
-11. If [synchronizer](/glossary.md#synchronizer) is enabled and module has this option, it synchronizes content.
-12. Brain creates an [answer](/glossary.md#answers) and forwards it to [TTS](/glossary.md#tts) synthesizer.
-13. TTS synthesizer transforms text answer (and send it to user as text) to audio buffer which is played by client.
+10. The [Brain](/glossary.md#brain) creates a child process and executes the chosen [module](/glossary.md#modules).
+11. If the [synchronizer](/glossary.md#synchronizer) is enabled and module has this option, it synchronizes the content.
+12. Brain creates an [answer](/glossary.md#answers) and forwards it to the [TTS](/glossary.md#tts) synthesizer.
+13. TTS synthesizer transforms the text answer (and sends it to the user as text) to audio buffer which is played by client.


### PR DESCRIPTION
I am absolutely in love with `Leon` and couldn't help but give in and propose my first contribution for it.
I was going through the docs and I found that there are some changes I could propose that would immensely increase readability. Would love someone to go through these.

> Have not created an issue for this because I thought It didn't need one for simple documentation changes.

1. Improved readability by adding proper punctuation and adding `The` wherever there is use of proper nouns.
2. Added a link to the MDN WebSocket documentation (could be later on changed to a link to Leon docs only after we add WebSockets into it).
3. Fixed some typographical changes.
4. Added some description to heading
5. Fixed past present tense errors.